### PR TITLE
Avoid Context leaks

### DIFF
--- a/app/src/main/java/io/fabianterhorst/fastlayout/sample/AppLayouts.java
+++ b/app/src/main/java/io/fabianterhorst/fastlayout/sample/AppLayouts.java
@@ -1,5 +1,7 @@
 package io.fabianterhorst.fastlayout.sample;
 
+import android.support.annotation.NonNull;
+
 import io.fabianterhorst.fastlayout.annotations.Layouts;
 
 /**

--- a/app/src/main/java/io/fabianterhorst/fastlayout/sample/MainActivity.java
+++ b/app/src/main/java/io/fabianterhorst/fastlayout/sample/MainActivity.java
@@ -11,7 +11,7 @@ public class MainActivity extends AppCompatActivity {
         //Default
         //setContentView(new ActivityMainLayout(this));
         //The cache is reusing the object to improve the performance
-        ActivityMainLayout layout = LayoutCache.getInstance(this).getLayout(LayoutCache.Activity_Main_Layout);
+        ActivityMainLayout layout = LayoutCache.getInstance().getLayout(this, LayoutCache.Activity_Main_Layout);
         setContentView(layout);
     }
 }

--- a/fastlayout-processor/src/main/resources/io/fabianterhorst/fastlayout/processor/layoutcache.ftl
+++ b/fastlayout-processor/src/main/resources/io/fabianterhorst/fastlayout/processor/layoutcache.ftl
@@ -2,6 +2,7 @@ package ${package};
 
 import android.content.Context;
 import android.support.annotation.StringDef;
+import android.support.annotation.NonNull;
 import android.view.View;
 
 import java.lang.annotation.Retention;
@@ -16,8 +17,6 @@ public class LayoutCache {
 
     private final HashMap<String, ILayout> mLayouts;
 
-    private final Context mContext;
-
     <#list layouts?keys as key>
     public static final String ${key} = "${layouts[key].name}";
 
@@ -27,19 +26,18 @@ public class LayoutCache {
     public @interface LayoutName {
     }
 
-    public LayoutCache(Context context) {
+    public LayoutCache() {
         mLayouts = new HashMap<>();
-        mContext = context;
     }
 
-    public static LayoutCache getInstance(Context context) {
+    public static LayoutCache getInstance() {
         if (mInstance == null) {
-            mInstance = new LayoutCache(context);
+            mInstance = new LayoutCache();
         }
         return mInstance;
     }
 
-    public <T extends View> T getLayout(@LayoutName String name) {
+    public <T extends View> T getLayout(@NonNull Context context, @LayoutName String name) {
         if (mLayouts.containsKey(name)) {
             return (T) mLayouts.get(name).clone();
         }
@@ -47,7 +45,7 @@ public class LayoutCache {
         switch (name) {
         <#list layouts?keys as key>
             case ${key}:
-                layout = new ${layouts[key].name}(mContext);
+                layout = new ${layouts[key].name}(context);
                 break;
         </#list>
         }


### PR DESCRIPTION
An activity won't be garbage collected if LayoutCache holds it's Context, so it's better to provide the Context every time you want get the layout.

I think .clone()ing may be a problem since it is also cloning the old Context?
